### PR TITLE
fix: replace deprecated import

### DIFF
--- a/qualtricssurvey/mixins/fragment.py
+++ b/qualtricssurvey/mixins/fragment.py
@@ -8,7 +8,7 @@ split into its own library.
 
 from django.template.context import Context
 from xblock.core import XBlock
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 
 class XBlockFragmentBuilderMixin:


### PR DESCRIPTION
# Overview
This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.

# Test Instructions
- Checkout the branch
- Update settings?
- Anything else?

# TODO
- [ ] Compile static assets
- [ ] Lint all files
- [ ] Pass all tests
- [ ] Bump the version number in `setup.py`
- [ ] Attach screenshots?
- [ ] Code Reviewer 1:
- [ ] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
