### PR TITLE
Upgrade to django5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [django32, django42, quality, csslint, eslint]
+        toxenv: [django42, django52, quality, csslint, eslint]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from os import path
 from setuptools import find_packages, setup
 
 
-version = '2.0.1'
+version = '2.1.0'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:
@@ -120,8 +120,8 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Topic :: Education',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = csslint,eslint,py{311,312}-django{42},quality
+envlist = csslint,eslint,py{311,312}-django{42,52},quality
 
 [testenv]
 deps = 
-    django32: Django>=3.2,<4.0
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -rrequirements/test.txt
 commands = 
     coverage run manage.py test


### PR DESCRIPTION
Resolves: #196 

- upgardes to django 5.2
- keeps backward compatibility with django 4.2

# Test Instructions
- Checkout the branch
- Update settings?
- Anything else?

# TODO
- [ ] Compile static assets
- [ ] Lint all files
- [ ] Pass all tests
- [ ] Bump the version number in `setup.py`
- [ ] Attach screenshots?
- [ ] Code Reviewer 1:
- [ ] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
