### PR TITLE
docs: update README with migration notice to xblocks-extra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,25 @@
-.. image:: https://img.shields.io/badge/status-deprecated-red
+.. image:: https://img.shields.io/badge/status-archived-red
    :alt: Status
 
 .. warning::
 
-   **This Repository is Deprecated**
+   ⚠️ Repository Migration Notice ⚠️
+   ***********************************
 
-   This repository is no longer maintained.
+   **Repository Migration:**
+   This ``xblock-qualtrics-survey`` repository is being archived. The Qualtrics Survey XBlock
+   is moving to the `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ repository,
+   which consolidates optional add-on XBlocks for the Open edX platform.
 
-   The Qualtrics Survey XBlock has been moved to:
-   https://github.com/openedx/xblocks-extra
+   The migration is being completed through this Pull Request:
+   `openedx/xblocks-extra#15 — feat: add Qualtrics Survey XBlock <https://github.com/openedx/xblocks-extra/pull/15>`_
 
-   Please use the new repository for all future work.
+   **Archival:** This repository will become read-only once the migration is complete.
+   No further updates or changes will be accepted here.
+
+   Please use `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ for all future work.
+   If you have any questions or concerns, please use the
+   `xblocks-extra issue tracker <https://github.com/openedx/xblocks-extra/issues>`_.
 
 Qualtrics Survey
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,16 @@
-![Status](https://img.shields.io/badge/status-deprecated-red)
+.. image:: https://img.shields.io/badge/status-deprecated-red
+   :alt: Status
 
-> ## ⚠️ This Repository is Deprecated
-> This repository is no longer maintained.
->
-> The Qualtrics Survey XBlock has been moved to:
-> 👉 https://github.com/openedx/xblocks-extra
->
-> Please use the new repository for all future work.
+.. warning::
 
+   **This Repository is Deprecated**
+
+   This repository is no longer maintained.
+
+   The Qualtrics Survey XBlock has been moved to:
+   https://github.com/openedx/xblocks-extra
+
+   Please use the new repository for all future work.
 
 Qualtrics Survey
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,24 +1,23 @@
 .. image:: https://img.shields.io/badge/status-archived-red
    :alt: Status
 
+⚠️ Repository Migration Notice ⚠️
+***********************************
+
 .. warning::
 
-   ⚠️ Repository Migration Notice ⚠️
-   ***********************************
-
-   **Repository Migration:**
    This ``xblock-qualtrics-survey`` repository is being archived. The Qualtrics Survey XBlock
    is moving to the `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ repository,
    which consolidates optional add-on XBlocks for the Open edX platform.
 
-   The migration is being completed through this Pull Request:
+   The migration is being completed through:
    `openedx/xblocks-extra#15 — feat: add Qualtrics Survey XBlock <https://github.com/openedx/xblocks-extra/pull/15>`_
 
    **Archival:** This repository will become read-only once the migration is complete.
    No further updates or changes will be accepted here.
 
    Please use `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ for all future work.
-   If you have any questions or concerns, please use the
+   If you have any questions or concerns, please open an issue on the
    `xblocks-extra issue tracker <https://github.com/openedx/xblocks-extra/issues>`_.
 
 Qualtrics Survey

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,14 @@
+![Status](https://img.shields.io/badge/status-deprecated-red)
+
+> ## ⚠️ This Repository is Deprecated
+> This repository is no longer maintained.
+>
+> The Qualtrics Survey XBlock has been moved to:
+> 👉 https://github.com/openedx/xblocks-extra
+>
+> Please use the new repository for all future work.
+
+
 Qualtrics Survey
 ==================
 


### PR DESCRIPTION
Updates the deprecation notice to clarify that this repository is being archived and the block is migrating to https://github.com/openedx/xblocks-extra/pull/15. Points users to the new repo for all future work.